### PR TITLE
* rn2483.cpp: Use unsigned for `i' variables to allay signed comparison warnings.

### DIFF
--- a/src/rn2483.cpp
+++ b/src/rn2483.cpp
@@ -395,7 +395,7 @@ void rn2483::sendEncoded(String input)
 {
   char working;
   char buffer[3];
-  for(int i=0; i<input.length(); i++)
+  for (unsigned i=0; i<input.length(); i++)
   {
     working = input.charAt(i);
     sprintf(buffer, "%02x", int(working));
@@ -410,7 +410,7 @@ String rn2483::base16encode(String input)
   input.trim();
   input.toCharArray(charsIn, input.length()+1);
   
-  int i = 0;
+  unsigned i = 0;
   for(i = 0; i<input.length()+1; i++)
   {
     if(charsIn[i] == '\0') break;
@@ -434,7 +434,7 @@ String rn2483::base16decode(String input)
   input.trim();
   input.toCharArray(charsIn, input.length()+1);
   
-  int i = 0;
+  unsigned i = 0;
   for(i = 0; i<input.length()/2+1; i++)
   {
     if(charsIn[i*2] == '\0') break;

--- a/src/rn2483.cpp
+++ b/src/rn2483.cpp
@@ -238,7 +238,7 @@ void rn2483::txUncnf(String data)
   txData("mac tx uncnf 1 ", data, true);
 }
 
-bool rn2483::txData(String data, bool shouldEncode)
+void rn2483::txData(String data, bool shouldEncode)
 {
   txData("mac tx uncnf 1 ", data, shouldEncode);
 }

--- a/src/rn2483.h
+++ b/src/rn2483.h
@@ -101,7 +101,7 @@ class rn2483
      * Transmit the provided data as an uncorfirmed message. 
      * bool should the data be HEX encoded or not
      */
-    bool txData(String, bool);
+    void txData(String, bool);
     
     /*
      * Change the datarate at which the RN2483 transmits.


### PR DESCRIPTION
Bringing patch over from the ttnmapperarduino repository.
