### PR TITLE
add check for esp8266 as suggested by @jpmeijers

### DIFF
--- a/src/rn2483.h
+++ b/src/rn2483.h
@@ -10,7 +10,7 @@
 #define rn2483_h
 
 #include "Arduino.h"
-#if defined(ARDUINO_ARCH_AVR)
+#if defined(ARDUINO_ARCH_AVR) || defined(ESP8266)
  #include <SoftwareSerial.h>
 #endif
 


### PR DESCRIPTION
This pull request adds a check for the esp8266 to use the SoftSerial lib
