### PR TITLE
Enable blue led when trying to connect to TTN

### DIFF
--- a/examples/SodaqOne-TTN-Mapper-binary/SodaqOne-TTN-Mapper-binary.ino
+++ b/examples/SodaqOne-TTN-Mapper-binary/SodaqOne-TTN-Mapper-binary.ino
@@ -1,34 +1,34 @@
 /*
  * Author: JP Meijers
  * Date: 2016-09-02
- * 
- * Transmit GPS coordinates via TTN. This happens as fast as possible, while still keeping to 
- * the 1% duty cycle rules enforced by the RN2483's built in LoRaWAN stack. Even though this is 
+ *
+ * Transmit GPS coordinates via TTN. This happens as fast as possible, while still keeping to
+ * the 1% duty cycle rules enforced by the RN2483's built in LoRaWAN stack. Even though this is
  * allowed by the radio regulations of the 868MHz band, the fair use policy of TTN may prohibit this.
- * 
+ *
  * CHECK THE RULES BEFORE USING THIS PROGRAM!
- * 
+ *
  * CHANGE ADDRESS!
- * Change the device address, network (session) key, and app (session) key to the values 
+ * Change the device address, network (session) key, and app (session) key to the values
  * that are registered via the TTN dashboard.
  * The appropriate line is "myLora.initABP(XXX);" or "myLora.initOTAA(XXX);"
  * When using ABP, it is advised to enable "relax frame count".
- * 
+ *
  * This sketch assumes you are using the Sodaq One V4 node in its original configuration.
- * 
+ *
  * This program makes use of the Sodaq UBlox library, but with minor changes to include altitude and HDOP.
- * 
+ *
  * LED indicators:
  * Blue: Busy transmitting a packet
  * Green waiting for a new GPS fix
  * Red: GPS fix taking a long time. Try to go outdoors.
- * 
+ *
  */
 #include <Arduino.h>
 #include "Sodaq_UBlox_GPS.h"
 #include <rn2xx3.h>
 
-//create an instance of the rn2xx3 library, 
+//create an instance of the rn2xx3 library,
 //giving the software serial as port to use
 rn2xx3 myLora(Serial1);
 
@@ -53,7 +53,7 @@ void setup()
     SerialUSB.println("SODAQ LoRaONE TTN Mapper starting");
 
     initialize_radio();
-  
+
     //transmit a startup message
     myLora.tx("TTN Mapper on Sodaq One");
 
@@ -75,7 +75,7 @@ void initialize_radio()
   while(Serial1.available()){
     Serial1.read();
   }
-  
+
   //print out the HWEUI so that we can register it via ttnctl
   String hweui = myLora.hweui();
   while(hweui.length() != 16)
@@ -92,10 +92,10 @@ void initialize_radio()
   //configure your keys and join the network
   SerialUSB.println("Trying to join TTN");
   bool join_result = false;
-  
+
   //ABP: initABP(String addr, String AppSKey, String NwkSKey);
   join_result = myLora.initABP("02017201", "8D7FFEF938589D95AAD928C2E2E7E48F", "AE17E567AECC8787F749A62F5541D522");
-  
+
   //OTAA: initOTAA(String AppEUI, String AppKey);
   //join_result = myLora.initOTAA("70B3D57ED00001A6", "A23C96EE13804963F8C2BD6285448198");
 
@@ -103,20 +103,22 @@ void initialize_radio()
   {
     SerialUSB.println("Unable to join. Are your keys correct, and do you have TTN coverage?");
     delay(60000); //delay a minute before retry
+    digitalWrite(LED_BLUE, LOW);
     join_result = myLora.init();
+    digitalWrite(LED_BLUE, HIGH);
   }
   SerialUSB.println("Successfully joined TTN");
-  
+
 }
 
 void loop()
 {
   SerialUSB.println("Waiting for GPS fix");
-  
+
   digitalWrite(LED_GREEN, LOW);
   sodaq_gps.scan();
   digitalWrite(LED_GREEN, HIGH);
-  
+
   while(sodaq_gps.getLat()==0.0)
   {
     digitalWrite(LED_RED, LOW);
@@ -130,11 +132,11 @@ void loop()
   txBuffer[0] = ( LatitudeBinary >> 16 ) & 0xFF;
   txBuffer[1] = ( LatitudeBinary >> 8 ) & 0xFF;
   txBuffer[2] = LatitudeBinary & 0xFF;
-  
+
   txBuffer[3] = ( LongitudeBinary >> 16 ) & 0xFF;
   txBuffer[4] = ( LongitudeBinary >> 8 ) & 0xFF;
   txBuffer[5] = LongitudeBinary & 0xFF;
-  
+
   altitudeGps = sodaq_gps.getAlt();
   txBuffer[6] = ( altitudeGps >> 8 ) & 0xFF;
   txBuffer[7] = altitudeGps & 0xFF;

--- a/src/rn2xx3.cpp
+++ b/src/rn2xx3.cpp
@@ -16,7 +16,7 @@ extern "C" {
 }
 
 /*
-  @param serial Needs to be an already opened Stream ({Software/Hardwre}Serial) to write to and read from.
+  @param serial Needs to be an already opened Stream ({Software/Hardware}Serial) to write to and read from.
 */
 rn2xx3::rn2xx3(Stream& serial):
 _serial(serial)
@@ -42,7 +42,7 @@ void rn2xx3::autobaud()
 RN2xx3_t rn2xx3::configureModuleType()
 {
   String version = sysver();
-  String model = version.substring(2,6);  
+  String model = version.substring(2,6);
   switch (model.toInt()) {
     case 2903:
       _moduleType = RN2903;
@@ -51,7 +51,7 @@ RN2xx3_t rn2xx3::configureModuleType()
       _moduleType = RN2483;
       break;
     default:
-      _moduleType = RN_NA; 
+      _moduleType = RN_NA;
       break;
   }
   return _moduleType;
@@ -125,7 +125,7 @@ bool rn2xx3::initOTAA(String AppEUI, String AppKey)
     default:
       // we shouldn't go forward with the init
       return false;
-  }    
+  }
   receivedData = _serial.readStringUntil('\n');
 
   _serial.println("mac set appeui "+_appeui);
@@ -202,7 +202,7 @@ bool rn2xx3::initABP(String devAddr, String AppSKey, String NwkSKey)
     _serial.read();
 
   configureModuleType();
-  
+
   switch (_moduleType) {
     case RN2903:
       _serial.println("mac reset");
@@ -217,8 +217,8 @@ bool rn2xx3::initABP(String devAddr, String AppSKey, String NwkSKey)
     default:
       // we shouldn't go forward with the init
       return false;
-  }    
- 
+  }
+
   _serial.println("mac set nwkskey "+_nwkskey);
   _serial.readStringUntil('\n');
   _serial.println("mac set appskey "+_appskey);
@@ -557,10 +557,10 @@ void rn2xx3::setFrequencyPlan(FREQ_PLAN fp)
       sendRawCommand(F("mac set ch dcycle 1 65535")); //almost never use this channel
       sendRawCommand(F("mac set ch dcycle 2 65535")); //almost never use this channel
       break;
-      
+
     case TTN_EU:
       break;
-      
+
     case DEFAULT_EU:
     default:
       //set 868.1, 868.3 and 868.5


### PR DESCRIPTION
At the moment there is no possibility to connect to TTN the Sodaq just is idle, nothing is visible, but when it has a connection we give green/red led status. Made a change so that at the moment we try to connect to TTN we give a blue led, this way once per second we give a small blue led status that the board is running and doing something, at the moment we do get a TTN connection the code enables the green led, at the moment we have GPS it then turns red. Fixed a small typo in comment and zapped trailing spaces.