### PR TITLE
Use GPS_ENABLE instead of 27 when initialize the GPS

### DIFF
--- a/examples/ArduinoUnoNano-basic/ArduinoUnoNano-basic.ino
+++ b/examples/ArduinoUnoNano-basic/ArduinoUnoNano-basic.ino
@@ -2,22 +2,22 @@
  * Author: JP Meijers
  * Date: 2016-02-07
  * Previous filename: TTN-Mapper-TTNEnschede-V1
- * 
+ *
  * This program is meant to be used with an Arduino UNO or NANO, conencted to an RNxx3 radio module.
  * It will most likely also work on other compatible Arduino or Arduino compatible boards, like The Things Uno, but might need some slight modifications.
- * 
- * Transmit a one byte packet via TTN. This happens as fast as possible, while still keeping to 
- * the 1% duty cycle rules enforced by the RN2483's built in LoRaWAN stack. Even though this is 
+ *
+ * Transmit a one byte packet via TTN. This happens as fast as possible, while still keeping to
+ * the 1% duty cycle rules enforced by the RN2483's built in LoRaWAN stack. Even though this is
  * allowed by the radio regulations of the 868MHz band, the fair use policy of TTN may prohibit this.
- * 
+ *
  * CHECK THE RULES BEFORE USING THIS PROGRAM!
- * 
+ *
  * CHANGE ADDRESS!
- * Change the device address, network (session) key, and app (session) key to the values 
+ * Change the device address, network (session) key, and app (session) key to the values
  * that are registered via the TTN dashboard.
  * The appropriate line is "myLora.initABP(XXX);" or "myLora.initOTAA(XXX);"
  * When using ABP, it is advised to enable "relax frame count".
- * 
+ *
  * Connect the RN2xx3 as follows:
  * RN2xx3 -- Arduino
  * Uart TX -- 10
@@ -25,32 +25,32 @@
  * Reset -- 12
  * Vcc -- 3.3V
  * Gnd -- Gnd
- * 
- * If you use an Arduino with a free hardware serial port, you can replace 
+ *
+ * If you use an Arduino with a free hardware serial port, you can replace
  * the line "rn2xx3 myLora(mySerial);"
  * with     "rn2xx3 myLora(SerialX);"
  * where the parameter is the serial port the RN2xx3 is connected to.
  * Remember that the serial port should be initialised before calling initTTN().
  * For best performance the serial port should be set to 57600 baud, which is impossible with a software serial port.
  * If you use 57600 baud, you can remove the line "myLora.autobaud();".
- * 
+ *
  */
 #include <rn2xx3.h>
 #include <SoftwareSerial.h>
 
 SoftwareSerial mySerial(10, 11); // RX, TX
 
-//create an instance of the rn2xx3 library, 
+//create an instance of the rn2xx3 library,
 //giving the software serial as port to use
 rn2xx3 myLora(mySerial);
 
 // the setup routine runs once when you press reset:
-void setup() 
+void setup()
 {
   //output LED pin
   pinMode(13, OUTPUT);
   led_on();
-  
+
   // Open serial communications and wait for port to open:
   Serial.begin(57600); //serial port to computer
   mySerial.begin(9600); //serial port to radio
@@ -83,7 +83,7 @@ void initialize_radio()
   String hweui = myLora.hweui();
   while(hweui.length() != 16)
   {
-    Serial.println("Communication with RN2xx3 unsuccesful. Power cycle the board.");
+    Serial.println("Communication with RN2xx3 unsuccessful. Power cycle the board.");
     Serial.println(hweui);
     delay(10000);
     hweui = myLora.hweui();
@@ -98,10 +98,10 @@ void initialize_radio()
   //configure your keys and join the network
   Serial.println("Trying to join TTN");
   bool join_result = false;
-  
+
   //ABP: initABP(String addr, String AppSKey, String NwkSKey);
   join_result = myLora.initABP("02017201", "8D7FFEF938589D95AAD928C2E2E7E48F", "AE17E567AECC8787F749A62F5541D522");
-  
+
   //OTAA: initOTAA(String AppEUI, String AppKey);
   //join_result = myLora.initOTAA("70B3D57ED00001A6", "A23C96EE13804963F8C2BD6285448198");
 
@@ -112,17 +112,17 @@ void initialize_radio()
     join_result = myLora.init();
   }
   Serial.println("Successfully joined TTN");
-  
+
 }
 
 // the loop routine runs over and over again forever:
-void loop() 
+void loop()
 {
     led_on();
 
     Serial.println("TXing");
     myLora.tx("!"); //one byte, blocking function
-    
+
     led_off();
     delay(200);
 }

--- a/examples/ESP8266-RN2483-basic/ESP8266-RN2483-basic.ino
+++ b/examples/ESP8266-RN2483-basic/ESP8266-RN2483-basic.ino
@@ -1,19 +1,19 @@
 /*
  * Author: JP Meijers
  * Date: 2016-10-20
- * 
- * Transmit a one byte packet via TTN. This happens as fast as possible, while still keeping to 
- * the 1% duty cycle rules enforced by the RN2483's built in LoRaWAN stack. Even though this is 
+ *
+ * Transmit a one byte packet via TTN. This happens as fast as possible, while still keeping to
+ * the 1% duty cycle rules enforced by the RN2483's built in LoRaWAN stack. Even though this is
  * allowed by the radio regulations of the 868MHz band, the fair use policy of TTN may prohibit this.
- * 
+ *
  * CHECK THE RULES BEFORE USING THIS PROGRAM!
- * 
+ *
  * CHANGE ADDRESS!
- * Change the device address, network (session) key, and app (session) key to the values 
+ * Change the device address, network (session) key, and app (session) key to the values
  * that are registered via the TTN dashboard.
  * The appropriate line is "myLora.initABP(XXX);" or "myLora.initOTAA(XXX);"
  * When using ABP, it is advised to enable "relax frame count".
- * 
+ *
  * Connect the RN2xx3 as follows:
  * RN2xx3 -- ESP8266
  * Uart TX -- GPIO4
@@ -21,7 +21,7 @@
  * Reset -- GPIO15
  * Vcc -- 3.3V
  * Gnd -- Gnd
- * 
+ *
  */
 #include <rn2xx3.h>
 #include <SoftwareSerial.h>
@@ -47,7 +47,7 @@ void setup() {
   delay(1000); //wait for the arduino ide's serial console to open
 
   Serial.println("Startup");
-  
+
   initialize_radio();
 
   //transmit a startup message
@@ -64,7 +64,7 @@ void initialize_radio()
   digitalWrite(RESET, LOW);
   delay(100);
   digitalWrite(RESET, HIGH);
-  
+
   delay(100); //wait for the RN2xx3's startup message
   mySerial.flush();
 
@@ -72,12 +72,12 @@ void initialize_radio()
   String hweui = myLora.hweui();
   while(hweui.length() != 16)
   {
-    Serial.println("Communication with RN2xx3 unsuccesful. Power cycle the board.");
+    Serial.println("Communication with RN2xx3 unsuccessful. Power cycle the board.");
     Serial.println(hweui);
     delay(10000);
     hweui = myLora.hweui();
   }
-  
+
   //print out the HWEUI so that we can register it via ttnctl
   Serial.println("When using OTAA, register this DevEUI: ");
   Serial.println(hweui);
@@ -87,10 +87,10 @@ void initialize_radio()
   //configure your keys and join the network
   Serial.println("Trying to join TTN");
   bool join_result = false;
-  
+
   //ABP: initABP(String addr, String AppSKey, String NwkSKey);
   join_result = myLora.initABP("02017201", "8D7FFEF938589D95AAD928C2E2E7E48F", "AE17E567AECC8787F749A62F5541D522");
-  
+
   //OTAA: initOTAA(String AppEUI, String AppKey);
   //join_result = myLora.initOTAA("70B3D57ED00001A6", "A23C96EE13804963F8C2BD6285448198");
 
@@ -101,7 +101,7 @@ void initialize_radio()
     join_result = myLora.init();
   }
   Serial.println("Successfully joined TTN");
-  
+
 }
 
 // the loop routine runs over and over again forever:
@@ -110,7 +110,7 @@ void loop() {
 
     Serial.println("TXing");
     myLora.tx("!"); //one byte, blocking function
-    
+
     led_off();
     delay(200);
 }

--- a/examples/SodaqOne-TTN-Mapper-binary/SodaqOne-TTN-Mapper-binary.ino
+++ b/examples/SodaqOne-TTN-Mapper-binary/SodaqOne-TTN-Mapper-binary.ino
@@ -97,7 +97,7 @@ void initialize_radio()
   join_result = myLora.initABP("02017201", "8D7FFEF938589D95AAD928C2E2E7E48F", "AE17E567AECC8787F749A62F5541D522");
 
   //OTAA: initOTAA(String AppEUI, String AppKey);
-  //join_result = myLora.initOTAA("70B3D57EF0001F39", "55D517528FD26BA78E65D5E934BF4F8A");
+  //join_result = myLora.initOTAA("70B3D57ED00001A6", "A23C96EE13804963F8C2BD6285448198");
 
   while(!join_result)
   {

--- a/examples/SodaqOne-TTN-Mapper-binary/SodaqOne-TTN-Mapper-binary.ino
+++ b/examples/SodaqOne-TTN-Mapper-binary/SodaqOne-TTN-Mapper-binary.ino
@@ -57,8 +57,8 @@ void setup()
     //transmit a startup message
     myLora.tx("TTN Mapper on Sodaq One");
 
-    // initialize GPS with enable on pin 27
-    sodaq_gps.init(27);
+    // initialize GPS
+    sodaq_gps.init(GPS_ENABLE);
 
     // myLora.setDR(0); //set the datarate at which we measure. DR7 is the best.
     pinMode(LED_BLUE, OUTPUT);
@@ -80,7 +80,7 @@ void initialize_radio()
   String hweui = myLora.hweui();
   while(hweui.length() != 16)
   {
-    SerialUSB.println("Communication with RN2xx3 unsuccesful. Power cycle the Sodaq One board.");
+    SerialUSB.println("Communication with RN2xx3 unsuccessful. Power cycle the Sodaq One board.");
     delay(10000);
     hweui = myLora.hweui();
   }
@@ -97,7 +97,7 @@ void initialize_radio()
   join_result = myLora.initABP("02017201", "8D7FFEF938589D95AAD928C2E2E7E48F", "AE17E567AECC8787F749A62F5541D522");
 
   //OTAA: initOTAA(String AppEUI, String AppKey);
-  //join_result = myLora.initOTAA("70B3D57ED00001A6", "A23C96EE13804963F8C2BD6285448198");
+  //join_result = myLora.initOTAA("70B3D57EF0001F39", "55D517528FD26BA78E65D5E934BF4F8A");
 
   while(!join_result)
   {

--- a/examples/SodaqOneSimpleBicycleTracker/SodaqOneSimpleBicycleTracker.ino
+++ b/examples/SodaqOneSimpleBicycleTracker/SodaqOneSimpleBicycleTracker.ino
@@ -1,26 +1,26 @@
 /*
  * Author: JP Meijers
  * Date: 2016-09-02
- * 
- * Transmit GPS coordinates via LoRaWAN. This happens as fast as possible, while still keeping to 
- * the 1% duty cycle rules enforced by the RN2483's built in LoRaWAN stack. Even though this is 
+ *
+ * Transmit GPS coordinates via LoRaWAN. This happens as fast as possible, while still keeping to
+ * the 1% duty cycle rules enforced by the RN2483's built in LoRaWAN stack. Even though this is
  * allowed by the radio regulations of the 868MHz band, it can cause unnecessary collisions.
- * 
+ *
  * This sketch assumes you are using the Sodaq One V4 node in its original configuration.
- * 
+ *
  * This program makes use of the Sodaq UBlox library, but with minor changes to include altitude and HDOP.
- * 
+ *
  * LED indicators:
  * Blue: Busy transmitting a packet
  * Green waiting for a new GPS fix
  * Red: GPS fix taking a long time. Try to go outdoors.
- * 
+ *
  */
 #include <Arduino.h>
 #include "Sodaq_UBlox_GPS.h"
 #include <rn2xx3.h>
 
-//create an instance of the rn2xx3 library, 
+//create an instance of the rn2xx3 library,
 //giving Serial1 as stream to use for communication with the radio
 rn2xx3 myLora(Serial1);
 
@@ -40,16 +40,16 @@ void setup()
     SerialUSB.println("SODAQ ONE simple bicycle tracker");
 
     initialize_radio();
-  
+
     // transmit a startup message
     myLora.tx("SODAQ ONE startup");
 
-    // initialize GPS with enable on pin 27
-    sodaq_gps.init(27);
+    // initialize GPS
+    sodaq_gps.init(GPS_ENABLE);
 
-    // Set the datarate/spreading factor at which we commuincate. 
+    // Set the datarate/spreading factor at which we communicate.
     // DR5 is the fastest and best to use. DR0 is the slowest.
-    // myLora.setDR(0); 
+    // myLora.setDR(0);
 
     // LED pins as outputs. HIGH=Off, LOW=On
     pinMode(LED_BLUE, OUTPUT);
@@ -66,12 +66,12 @@ void initialize_radio()
   while(Serial1.available()){
     Serial1.read();
   }
-  
+
   //print out the HWEUI so that we can register it via ttnctl
   String hweui = myLora.hweui();
   while(hweui.length() != 16)
   {
-    SerialUSB.println("Communication with RN2xx3 unsuccesful. Power cycle the Sodaq One board.");
+    SerialUSB.println("Communication with RN2xx3 unsuccessful. Power cycle the Sodaq One board.");
     delay(10000);
     hweui = myLora.hweui();
   }
@@ -83,10 +83,10 @@ void initialize_radio()
   //configure your keys and join the network
   SerialUSB.println("Trying to join LoRaWAN network");
   bool join_result = false;
-  
+
   //ABP: initABP(String addr, String AppSKey, String NwkSKey);
   //join_result = myLora.initABP("02017201", "8D7FFEF938589D95AAD928C2E2E7E48F", "AE17E567AECC8787F749A62F5541D522");
-  
+
   //OTAA: initOTAA(String AppEUI, String AppKey);
   join_result = myLora.initOTAA("1122334455667788", "11111111111111111111111111111111");
 
@@ -97,13 +97,13 @@ void initialize_radio()
     join_result = myLora.init();
   }
   SerialUSB.println("Successfully joined network");
-  
+
 }
 
 void loop()
 {
   SerialUSB.println("Waiting for GPS fix");
-  
+
   digitalWrite(LED_GREEN, LOW);
   sodaq_gps.scan();
   digitalWrite(LED_GREEN, HIGH);

--- a/examples/TheThingsUno-GPSshield-TTN-Mapper-binary/TheThingsUno-GPSshield-TTN-Mapper-binary.ino
+++ b/examples/TheThingsUno-GPSshield-TTN-Mapper-binary/TheThingsUno-GPSshield-TTN-Mapper-binary.ino
@@ -1,39 +1,39 @@
 /*
  * Author: JP Meijers
  * Date: 2016-09-07
- * 
- * This example program is meant for a The Things UNO board with an 
- * "Adafruit Ultimate GPS+Logging Shield" on top of it. Make sure the switch on 
+ *
+ * This example program is meant for a The Things UNO board with an
+ * "Adafruit Ultimate GPS+Logging Shield" on top of it. Make sure the switch on
  * the GPS shield is switched to the "Soft. Serial" position.
  *
- * Coordinates from the GPS is packed into a LoRaWan packet using binary 
- * encoding, and then sent out on the air using the TTN UNO's RN2xx3 module. 
- * This happens as fast as possible, while still keeping to the 1% duty cycle 
- * rules enforced by the RN2483's built in LoRaWAN stack. Even though this is 
- * allowed by the radio regulations of the 868MHz band, the fair use policy of 
+ * Coordinates from the GPS is packed into a LoRaWan packet using binary
+ * encoding, and then sent out on the air using the TTN UNO's RN2xx3 module.
+ * This happens as fast as possible, while still keeping to the 1% duty cycle
+ * rules enforced by the RN2483's built in LoRaWAN stack. Even though this is
+ * allowed by the radio regulations of the 868MHz band, the fair use policy of
  * TTN may prohibit this.
- * 
+ *
  * CHECK THE RULES BEFORE USING THIS PROGRAM!
- * 
+ *
  * CHANGE ADDRESS!
- * Change the device address, network (session) key, and app (session) key to 
+ * Change the device address, network (session) key, and app (session) key to
  * the values that are registered via the TTN dashboard.
  * The appropriate line is "myLora.initABP(XXX);" or "myLora.initOTAA(XXX);"
  * When using ABP, it is advised to enable "relax frame count" on the dashboard.
  *
  * TO CONTRIBUTE TO TTN Mapper:
- * 1. Register a new Application and/or new device on the 
+ * 1. Register a new Application and/or new device on the
  *     TTN Dashboard (https://staging.thethingsnetwork.org).
- * 2. Copy the correct keys into the line "myLora.initABP(XXX);" 
+ * 2. Copy the correct keys into the line "myLora.initABP(XXX);"
  *     or "myLora.initOTAA(XXX);" in this program.
- * 3. Comment out or remove the line: "while(!Serial); //wait for Serial to 
+ * 3. Comment out or remove the line: "while(!Serial); //wait for Serial to
        be available - remove this line after successful test run"
- * 4. Make sure packets are arriving on the TTN Dashboard when your node is 
+ * 4. Make sure packets are arriving on the TTN Dashboard when your node is
  *     powered and in reach of a gateway.
  * 5. Share your Application EUI, Access Key and Device EUI with
  *     contribute@ttnmapper.org so that your measurements can be automatically
  *     imported into TTN Mapper.
- * 
+ *
  */
 #include "TinyGPS++.h"
 #include <SoftwareSerial.h>
@@ -58,7 +58,7 @@ void setup() {
   //output LED pin
   pinMode(13, OUTPUT);
   led_on();
-  
+
   Serial.begin(57600); //serial to computer
   gpsSerial.begin(9600); //serial to gps
   Serial1.begin(57600); //serial to RN2xx3
@@ -67,7 +67,7 @@ void setup() {
   // or after 10s go on anyway for 'headless' use of the
   // node.
   while ((!Serial) && (millis() < 10000));
-  
+
   Serial.println("TTN UNO + GPS shield startup");
 
   //set up RN2xx3
@@ -86,12 +86,12 @@ void initialize_radio()
 {
   delay(100); //wait for the RN2xx3's startup message
   Serial1.flush();
-  
+
   //print out the HWEUI so that we can register it via ttnctl
   String hweui = myLora.hweui();
   while(hweui.length() != 16)
   {
-    Serial.println("Communication with RN2xx3 unsuccesful. Power cycle the TTN UNO board.");
+    Serial.println("Communication with RN2xx3 unsuccessful. Power cycle the TTN UNO board.");
     delay(10000);
     hweui = myLora.hweui();
   }
@@ -103,10 +103,10 @@ void initialize_radio()
   //configure your keys and join the network
   Serial.println("Trying to join TTN");
   bool join_result = false;
-  
+
   //ABP: initABP(String addr, String AppSKey, String NwkSKey);
   join_result = myLora.initABP("02017201", "8D7FFEF938589D95AAD928C2E2E7E48F", "AE17E567AECC8787F749A62F5541D522");
-  
+
   //OTAA: initOTAA(String AppEUI, String AppKey);
   //join_result = myLora.initOTAA("70B3D57ED00001A6", "A23C96EE13804963F8C2BD6285448198");
 
@@ -117,14 +117,14 @@ void initialize_radio()
     join_result = myLora.init();
   }
   Serial.println("Successfully joined TTN");
-  
+
 }
 
 void loop() {
   while (gpsSerial.available()){
     gps.encode(gpsSerial.read());
   }
-  
+
   if (gps.location.age() < 1000 && (millis() - last_update) >= 1000) {
     led_on();
     Serial.print("Interval: ");
@@ -151,11 +151,11 @@ void build_packet()
   txBuffer[0] = ( LatitudeBinary >> 16 ) & 0xFF;
   txBuffer[1] = ( LatitudeBinary >> 8 ) & 0xFF;
   txBuffer[2] = LatitudeBinary & 0xFF;
-  
+
   txBuffer[3] = ( LongitudeBinary >> 16 ) & 0xFF;
   txBuffer[4] = ( LongitudeBinary >> 8 ) & 0xFF;
   txBuffer[5] = LongitudeBinary & 0xFF;
-  
+
   altitudeGps = gps.altitude.meters();
   txBuffer[6] = ( altitudeGps >> 8 ) & 0xFF;
   txBuffer[7] = altitudeGps & 0xFF;

--- a/examples/TheThingsUno-basic/TheThingsUno-basic.ino
+++ b/examples/TheThingsUno-basic/TheThingsUno-basic.ino
@@ -3,20 +3,20 @@
  * Date: 2016-09-07
  *
  * This program is meant to be used on a The Things Uno board.
- * 
- * Transmit a one byte packet via TTN. This happens as fast as possible, 
- * while still keeping to the 1% duty cycle rules enforced by the RN2483's built 
+ *
+ * Transmit a one byte packet via TTN. This happens as fast as possible,
+ * while still keeping to the 1% duty cycle rules enforced by the RN2483's built
  * in LoRaWAN stack. Even though this is allowed by the radio regulations of the
  * 868MHz band, the fair use policy of TTN may prohibit this.
- * 
+ *
  * CHECK THE RULES BEFORE USING THIS PROGRAM!
- * 
+ *
  * CHANGE ADDRESS!
- * Change the device address, network (session) key, and app (session) key to 
+ * Change the device address, network (session) key, and app (session) key to
  * the values that are registered via the TTN dashboard.
  * The appropriate line is "myLora.initABP(XXX);" or "myLora.initOTAA(XXX);"
  * When using ABP, it is advised to enable "relax frame count" on the dashboard.
- * 
+ *
  */
 #include <rn2xx3.h>
 
@@ -24,12 +24,12 @@
 rn2xx3 myLora(Serial1);
 
 // the setup routine runs once when you press reset:
-void setup() 
+void setup()
 {
   //output LED pin
   pinMode(13, OUTPUT);
   led_on();
-  
+
   // Open serial communications and wait for port to open:
   Serial.begin(57600); //serial port to computer
   Serial1.begin(57600); //serial port to radio
@@ -38,7 +38,7 @@ void setup()
   // or after 10s go on anyway for 'headless' use of the
   // node.
   while ((!Serial) && (millis() < 10000));
-  
+
   Serial.println("Startup");
 
   initialize_radio();
@@ -54,12 +54,12 @@ void initialize_radio()
 {
   delay(100); //wait for the RN2xx3's startup message
   Serial1.flush();
-  
+
   //print out the HWEUI so that we can register it via ttnctl
   String hweui = myLora.hweui();
   while(hweui.length() != 16)
   {
-    Serial.println("Communication with RN2xx3 unsuccesful. Power cycle the TTN UNO board.");
+    Serial.println("Communication with RN2xx3 unsuccessful. Power cycle the TTN UNO board.");
     delay(10000);
     hweui = myLora.hweui();
   }
@@ -71,10 +71,10 @@ void initialize_radio()
   //configure your keys and join the network
   Serial.println("Trying to join TTN");
   bool join_result = false;
-  
+
   //ABP: initABP(String addr, String AppSKey, String NwkSKey);
   join_result = myLora.initABP("02017201", "8D7FFEF938589D95AAD928C2E2E7E48F", "AE17E567AECC8787F749A62F5541D522");
-  
+
   //OTAA: initOTAA(String AppEUI, String AppKey);
   //join_result = myLora.initOTAA("70B3D57ED00001A6", "A23C96EE13804963F8C2BD6285448198");
 
@@ -85,17 +85,17 @@ void initialize_radio()
     join_result = myLora.init();
   }
   Serial.println("Successfully joined TTN");
-  
+
 }
 
 // the loop routine runs over and over again forever:
-void loop() 
+void loop()
 {
     led_on();
 
     Serial.println("TXing");
     myLora.tx("!"); //one byte, blocking function
-    
+
     led_off();
     delay(200);
 }


### PR DESCRIPTION
Use GPS_ENABLE instead of 27 when initialize the GPS, see the sodaq one GPS example at http://support.sodaq.com/sodaq-one/loraone-gps. Also fixed some typos and removed trailing spaces