### PR TITLE
Keep the GPS enabled after a scan, increases accuracy of the GPS

### DIFF
--- a/examples/SodaqOne-TTN-Mapper-ascii/SodaqOne-TTN-Mapper-ascii.ino
+++ b/examples/SodaqOne-TTN-Mapper-ascii/SodaqOne-TTN-Mapper-ascii.ino
@@ -112,13 +112,15 @@ void loop()
   SerialUSB.println("Waiting for GPS fix");
 
   digitalWrite(LED_GREEN, LOW);
-  sodaq_gps.scan();
+  // Keep the GPS enabled after we do a scan, increases accuracy
+  sodaq_gps.scan(true);
   digitalWrite(LED_GREEN, HIGH);
 
   while(sodaq_gps.getLat()==0.0)
   {
     digitalWrite(LED_RED, LOW);
-    sodaq_gps.scan();
+    // Keep the GPS enabled after we do a scan, increases accuracy
+    sodaq_gps.scan(true);
     digitalWrite(LED_RED, HIGH);
   }
 

--- a/examples/SodaqOne-TTN-Mapper-binary/SodaqOne-TTN-Mapper-binary.ino
+++ b/examples/SodaqOne-TTN-Mapper-binary/SodaqOne-TTN-Mapper-binary.ino
@@ -58,6 +58,9 @@ void setup()
     //transmit a startup message
     myLora.tx("TTN Mapper on Sodaq One");
 
+    // Enable next line to enable debug information of the sodaq_gps
+    //sodaq_gps.setDiag(SerialUSB);
+
     // initialize GPS
     sodaq_gps.init(GPS_ENABLE);
 
@@ -117,7 +120,8 @@ void loop()
   SerialUSB.println("Waiting for GPS fix");
 
   digitalWrite(LED_GREEN, LOW);
-  sodaq_gps.scan();
+  // Keep the GPS enabled after we do a scan, increases accuracy
+  sodaq_gps.scan(true);
   digitalWrite(LED_GREEN, HIGH);
 
   while(sodaq_gps.getLat()==0.0)
@@ -125,7 +129,8 @@ void loop()
     SerialUSB.println("Latitude still 0.0, doing another scan");
 
     digitalWrite(LED_RED, LOW);
-    sodaq_gps.scan();
+    // Keep the GPS enabled after we do a scan, increases accuracy
+    sodaq_gps.scan(true);
     digitalWrite(LED_RED, HIGH);
   }
 

--- a/examples/SodaqOneAccelerometer/SodaqOneAccelerometer.ino
+++ b/examples/SodaqOneAccelerometer/SodaqOneAccelerometer.ino
@@ -156,7 +156,8 @@ void loop()
   //the timestamp is considered to be the start time of the sampling frame
 
   digitalWrite(LED_GREEN, LOW);
-  sodaq_gps.scan();
+  // Keep the GPS enabled after we do a scan, increases accuracy
+  sodaq_gps.scan(true);
 //  SerialUSB.println(sodaq_gps.getDateTimeString());
   uint32_t timestamp = unixTimestamp(sodaq_gps.getYear(), sodaq_gps.getMonth(), sodaq_gps.getDay(),
               sodaq_gps.getHour(), sodaq_gps.getMinute(), sodaq_gps.getSecond());

--- a/examples/SodaqOneSimpleBicycleTracker/SodaqOneSimpleBicycleTracker.ino
+++ b/examples/SodaqOneSimpleBicycleTracker/SodaqOneSimpleBicycleTracker.ino
@@ -105,14 +105,16 @@ void loop()
   SerialUSB.println("Waiting for GPS fix");
 
   digitalWrite(LED_GREEN, LOW);
-  sodaq_gps.scan();
+  // Keep the GPS enabled after we do a scan, increases accuracy
+  sodaq_gps.scan(true);
   digitalWrite(LED_GREEN, HIGH);
 
   // if the latitude is 0, we likely do not have a GPS fix yet, so wait longer
   while(sodaq_gps.getLat()==0.0)
   {
     digitalWrite(LED_RED, LOW);
-    sodaq_gps.scan();
+    // Keep the GPS enabled after we do a scan, increases accuracy
+    sodaq_gps.scan(true);
     digitalWrite(LED_RED, HIGH);
   }
 


### PR DESCRIPTION
It increases accurancy of the sodaq active GPS when we keep it online after doing a scan. This increases slightly the power usage because we keep the GPS online during a TTN data transmission but that is really a short period of time and in return we get much better HDOP values.