### PR TITLE
Enable -Werror, this should work soon because of a new SodaqOne base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ cache:
         - "~/.platformio"
 
 env:
-#    global:
-#        - PLATFORMIO_BUILD_FLAGS=-Werror
+    global:
+        - PLATFORMIO_BUILD_FLAGS=-Werror
     matrix:
         - PLATFORMIO_CI_SRC=examples/ArduinoUnoNano-basic PLATFORMIO_CI_EXTRA_ARGS="--board=uno"
         - PLATFORMIO_CI_SRC=examples/ArduinoUnoNano-downlink PLATFORMIO_CI_EXTRA_ARGS="--board=uno"


### PR DESCRIPTION
Sodaq has reported they are about to release an update, that should make it possible to use -Werror. WIth this PR we can check on travis-ci when it works again