### PR TITLE
Set DR on initOTAA

### DIFF
--- a/src/rn2xx3.cpp
+++ b/src/rn2xx3.cpp
@@ -174,6 +174,7 @@ bool rn2xx3::initOTAA(String AppEUI, String AppKey, String DevEUI)
   {
     sendRawCommand(F("mac set pwridx 1"));
   }
+  sendRawCommand(F("mac set dr 5")); //0= min, 7=max
 
   // TTN does not yet support Adaptive Data Rate.
   // Using it is also only necessary in limited situations.


### PR DESCRIPTION
We're using DR5 when using initABP(), however initOTAA() does not specify this meaning that it will fallback to DR0 (SF12, 2ms air time!).

Sounds unwanted