### PR TITLE
Change delay to get authorized by TTN

### DIFF
--- a/examples/ArduinoUnoNano-basic/ArduinoUnoNano-basic.ino
+++ b/examples/ArduinoUnoNano-basic/ArduinoUnoNano-basic.ino
@@ -139,7 +139,7 @@ void loop()
     myLora.tx("!"); //one byte, blocking function
 
     led_off();
-    delay(200);
+    delay(30000);
 }
 
 void led_on()


### PR DESCRIPTION
I had some troubles using this example, as TTN seems to block the devices if they send data too fast...
I juste changed the delay from 0.2sec to 30sec, the legal limit