### PR TITLE
Remove duplicate code and extra memory allocations

### DIFF
--- a/src/rn2xx3.cpp
+++ b/src/rn2xx3.cpp
@@ -37,7 +37,7 @@ void rn2xx3::autobaud()
     _serial.write(0x55);
     _serial.println();
     // we could use sendRawCommand(F("sys get ver")); here
-    _serial.println("sys get ver");
+    _serial.println(F("sys get ver"));
     response = _serial.readStringUntil('\n');
   }
 }
@@ -205,7 +205,7 @@ bool rn2xx3::initOTAA(String AppEUI, String AppKey, String DevEUI)
     // Parse 2nd response
     receivedData = _serial.readStringUntil('\n');
 
-    if(receivedData.startsWith("accepted"))
+    if(receivedData.startsWith(F("accepted")))
     {
       joined=true;
       delay(1000);
@@ -312,7 +312,7 @@ bool rn2xx3::initABP(String devAddr, String AppSKey, String NwkSKey)
   _serial.setTimeout(2000);
   delay(1000);
 
-  if(receivedData.startsWith("accepted"))
+  if(receivedData.startsWith(F("accepted")))
   {
     return true;
     //with abp we can always join successfully as long as the keys are valid
@@ -385,7 +385,7 @@ TX_RETURN_TYPE rn2xx3::txCommand(String command, String data, bool shouldEncode)
     String receivedData = _serial.readStringUntil('\n');
     //TODO: Debug print on receivedData
 
-    if(receivedData.startsWith("ok"))
+    if(receivedData.startsWith(F("ok")))
     {
       _serial.setTimeout(30000);
       receivedData = _serial.readStringUntil('\n');
@@ -393,14 +393,14 @@ TX_RETURN_TYPE rn2xx3::txCommand(String command, String data, bool shouldEncode)
 
       //TODO: Debug print on receivedData
 
-      if(receivedData.startsWith("mac_tx_ok"))
+      if(receivedData.startsWith(F("mac_tx_ok")))
       {
         //SUCCESS!!
         send_success = true;
         return TX_SUCCESS;
       }
 
-      else if(receivedData.startsWith("mac_rx"))
+      else if(receivedData.startsWith(F("mac_rx")))
       {
         //example: mac_rx 1 54657374696E6720313233
         _rxMessenge = receivedData.substring(receivedData.indexOf(' ', 7)+1);
@@ -408,26 +408,26 @@ TX_RETURN_TYPE rn2xx3::txCommand(String command, String data, bool shouldEncode)
         return TX_WITH_RX;
       }
 
-      else if(receivedData.startsWith("mac_err"))
+      else if(receivedData.startsWith(F("mac_err")))
       {
         init();
       }
 
-      else if(receivedData.startsWith("invalid_data_len"))
+      else if(receivedData.startsWith(F("invalid_data_len")))
       {
         //this should never happen if the prototype worked
         send_success = true;
         return TX_FAIL;
       }
 
-      else if(receivedData.startsWith("radio_tx_ok"))
+      else if(receivedData.startsWith(F("radio_tx_ok")))
       {
         //SUCCESS!!
         send_success = true;
         return TX_SUCCESS;
       }
 
-      else if(receivedData.startsWith("radio_err"))
+      else if(receivedData.startsWith(F("radio_err")))
       {
         //This should never happen. If it does, something major is wrong.
         init();
@@ -440,35 +440,35 @@ TX_RETURN_TYPE rn2xx3::txCommand(String command, String data, bool shouldEncode)
       }
     }
 
-    else if(receivedData.startsWith("invalid_param"))
+    else if(receivedData.startsWith(F("invalid_param")))
     {
       //should not happen if we typed the commands correctly
       send_success = true;
       return TX_FAIL;
     }
 
-    else if(receivedData.startsWith("not_joined"))
+    else if(receivedData.startsWith(F("not_joined")))
     {
       init();
     }
 
-    else if(receivedData.startsWith("no_free_ch"))
+    else if(receivedData.startsWith(F("no_free_ch")))
     {
       //retry
       delay(1000);
     }
 
-    else if(receivedData.startsWith("silent"))
+    else if(receivedData.startsWith(F("silent")))
     {
       init();
     }
 
-    else if(receivedData.startsWith("frame_counter_err_rejoin_needed"))
+    else if(receivedData.startsWith(F("frame_counter_err_rejoin_needed")))
     {
       init();
     }
 
-    else if(receivedData.startsWith("busy"))
+    else if(receivedData.startsWith(F("busy")))
     {
       busy_count++;
 
@@ -487,12 +487,12 @@ TX_RETURN_TYPE rn2xx3::txCommand(String command, String data, bool shouldEncode)
       }
     }
 
-    else if(receivedData.startsWith("mac_paused"))
+    else if(receivedData.startsWith(F("mac_paused")))
     {
       init();
     }
 
-    else if(receivedData.startsWith("invalid_data_len"))
+    else if(receivedData.startsWith(F("invalid_data_len")))
     {
       //should not happen if the prototype worked
       send_success = true;
@@ -609,6 +609,7 @@ String rn2xx3::sendRawCommand(String command)
   while(_serial.available())
     _serial.read();
   _serial.println(command);
+
   String ret = _serial.readStringUntil('\n');
   ret.trim();
 

--- a/src/rn2xx3.cpp
+++ b/src/rn2xx3.cpp
@@ -568,9 +568,12 @@ String rn2xx3::getRx() {
 
 int rn2xx3::getSNR()
 {
-  String snr = sendRawCommand(F("radio get snr"));
-  snr.trim();
-  return snr.toInt();
+  return readIntValue(F("radio get snr"));
+}
+
+int rn2xx3::getVbat()
+{
+  return readIntValue(F("sys get vdd"));
 }
 
 String rn2xx3::base16decode(String input)
@@ -818,7 +821,15 @@ rn2xx3::received_t rn2xx3::decodeReceived(const String& receivedData) {
 }
 
 
-String rn2xx3::getLastErrorInvalidParam() {
+int rn2xx3::readIntValue(const String& command)
+{
+  String value = sendRawCommand(command);
+  value.trim();
+  return value.toInt();
+}
+
+String rn2xx3::getLastErrorInvalidParam() 
+{
   String res = _lastErrorInvalidParam;
   _lastErrorInvalidParam = "";
   return res;

--- a/src/rn2xx3.h
+++ b/src/rn2xx3.h
@@ -317,7 +317,7 @@ class rn2xx3
     bool setChannelDataRateRange(unsigned int channel, unsigned int minRange, unsigned int maxRange);
 
     // Set channel enabled/disabled.
-    // Frequency, data range, duty cycle must be issued prior to enabling the status of that channe
+    // Frequency, data range, duty cycle must be issued prior to enabling the status of that channel
     bool setChannelEnabled(unsigned int channel, bool enabled);
     
     bool set2ndRecvWindow(unsigned int dataRate, uint32_t frequency);

--- a/src/rn2xx3.h
+++ b/src/rn2xx3.h
@@ -105,7 +105,7 @@ class rn2xx3
      * NwkSKey: Network Session Key as a HEX string.
      *          Example "AE17E567AECC8787F749A62F5541D522"
      */
-    bool initABP(String addr, String AppSKey, String NwkSKey);
+    bool initABP(const String& addr, const String& AppSKey, const String& NwkSKey);
 
     //TODO: initABP(uint8_t * addr, uint8_t * AppSKey, uint8_t * NwkSKey)
 
@@ -124,7 +124,7 @@ class rn2xx3
      * they will be used. Otherwise the join will fail and this function
      * will return false.
      */
-    bool initOTAA(String AppEUI="", String AppKey="", String DevEUI="");
+    bool initOTAA(const String& AppEUI="", const String& AppKey="", const String& DevEUI="");
 
     /*
      * Initialise the RN2xx3 and join a network using over the air activation,
@@ -144,7 +144,7 @@ class rn2xx3
      *
      * Parameter is an ascii text string.
      */
-    TX_RETURN_TYPE tx(String);
+    TX_RETURN_TYPE tx(const String&);
 
     /*
      * Transmit raw byte encoded data via LoRa WAN.
@@ -158,14 +158,14 @@ class rn2xx3
      *
      * Parameter is an ascii text string.
      */
-    TX_RETURN_TYPE txCnf(String);
+    TX_RETURN_TYPE txCnf(const String&);
 
     /*
      * Do an unconfirmed transmission via LoRa WAN.
      *
      * Parameter is an ascii text string.
      */
-    TX_RETURN_TYPE txUncnf(String);
+    TX_RETURN_TYPE txUncnf(const String&);
 
     /*
      * Transmit the provided data using the provided command.
@@ -175,7 +175,7 @@ class rn2xx3
      * String - an ascii text string if bool is true. A HEX string if bool is false.
      * bool - should the data string be hex encoded or not
      */
-    TX_RETURN_TYPE txCommand(String, String, bool);
+    TX_RETURN_TYPE txCommand(const String&, const String&, bool);
 
     /*
      * Change the datarate at which the RN2xx3 transmits.
@@ -232,13 +232,13 @@ class rn2xx3
      * Encode an ASCII string to a HEX string as needed when passed
      * to the RN2xx3 module.
      */
-    String base16encode(String);
+    String base16encode(const String&);
 
     /*
      * Decode a HEX string to an ASCII string. Useful to decode a
      * string received from the RN2xx3.
      */
-    String base16decode(String);
+    String base16decode(const String&);
 
     /*
      * Almost all commands can return "invalid_param"
@@ -282,7 +282,7 @@ class rn2xx3
      */
     RN2xx3_t configureModuleType();
 
-    void sendEncoded(String);
+    void sendEncoded(const String&);
 
     enum received_t {
       busy,
@@ -302,7 +302,7 @@ class rn2xx3
       UNKNOWN
     };
 
-    static received_t decodeReceived(const String& receivedData);
+    static received_t determineReceivedDataType(const String& receivedData);
 
     int readIntValue(const String& command);
 

--- a/src/rn2xx3.h
+++ b/src/rn2xx3.h
@@ -223,6 +223,12 @@ class rn2xx3
     int getSNR();
 
     /*
+     * Get the RN2xx3's voltage measurement on the Vdd in mVolt
+     * 0–3600 (decimal value from 0 to 3600)
+     */
+    int getVbat();
+
+    /*
      * Encode an ASCII string to a HEX string as needed when passed
      * to the RN2xx3 module.
      */
@@ -297,6 +303,8 @@ class rn2xx3
     };
 
     static received_t decodeReceived(const String& receivedData);
+
+    int readIntValue(const String& command);
 
 
     // All "mac set ..." commands return either "ok" or "invalid_param"

--- a/src/rn2xx3.h
+++ b/src/rn2xx3.h
@@ -41,26 +41,6 @@ class rn2xx3
 {
   public:
 
-    enum received_t {
-      busy,
-      frame_counter_err_rejoin_needed,
-      invalid_data_len,
-      invalid_param,
-      mac_err,
-      mac_paused,
-      mac_rx,
-      mac_tx_ok,
-      no_free_ch,
-      not_joined,
-      ok,
-      radio_err,
-      radio_tx_ok,
-      silent,
-      UNKNOWN
-    };
-
-    static received_t decodeReceived(const String& receivedData);
-
     /*
      * A simplified constructor taking only a Stream ({Software/Hardware}Serial) object.
      * The serial port should already be initialised when initialising this library.
@@ -218,7 +198,7 @@ class rn2xx3
      * Returns the raw string as received back from the RN2xx3.
      * If the RN2xx3 replies with multiple line, only the first line will be returned.
      */
-    String sendRawCommand(String command);
+    String sendRawCommand(const String& command);
 
     /*
      * Returns the module type either RN2903 or RN2483, or NA.
@@ -254,6 +234,13 @@ class rn2xx3
      */
     String base16decode(String);
 
+    /*
+     * Almost all commands can return "invalid_param"
+     * The last command resulting in such an error can be retrieved.
+     * Reading this will clear the error.
+     */
+    String getLastErrorInvalidParam();
+
   private:
     Stream& _serial;
 
@@ -261,8 +248,6 @@ class rn2xx3
 
     //Flags to switch code paths. Default is to use OTAA.
     bool _otaa = true;
-
-    bool _needsHardReset = false;
 
     //The default address to use on TTN if no address is defined.
     //This one falls in the "testing" address space.
@@ -284,12 +269,53 @@ class rn2xx3
     // The downlink messenge
     String _rxMessenge = "";
 
+    String _lastErrorInvalidParam = "";
+
     /*
      * Auto configure for either RN2903 or RN2483 module
      */
     RN2xx3_t configureModuleType();
 
     void sendEncoded(String);
+
+    enum received_t {
+      busy,
+      frame_counter_err_rejoin_needed,
+      invalid_data_len,
+      invalid_param,
+      mac_err,
+      mac_paused,
+      mac_rx,
+      mac_tx_ok,
+      no_free_ch,
+      not_joined,
+      ok,
+      radio_err,
+      radio_tx_ok,
+      silent,
+      UNKNOWN
+    };
+
+    static received_t decodeReceived(const String& receivedData);
+
+
+    // All "mac set ..." commands return either "ok" or "invalid_param"
+    bool sendMacSet(const String& param, const String& value);
+    bool sendMacSetEnabled(const String& param, bool enabled);
+    bool sendMacSetCh(const String& param, unsigned int channel, const String& value);
+    bool sendMacSetCh(const String& param, unsigned int channel, uint32_t value);
+    bool setChannelDutyCycle(unsigned int channel, unsigned int dutyCycle);
+    bool setChannelFrequency(unsigned int channel, uint32_t frequency);
+    bool setChannelDataRateRange(unsigned int channel, unsigned int minRange, unsigned int maxRange);
+
+    // Set channel enabled/disabled.
+    // Frequency, data range, duty cycle must be issued prior to enabling the status of that channe
+    bool setChannelEnabled(unsigned int channel, bool enabled);
+    
+    bool set2ndRecvWindow(unsigned int dataRate, uint32_t frequency);
+    bool setAdaptiveDataRate(bool enabled);
+    bool setAutomaticReply(bool enabled);
+    bool setTXoutputPower(int pwridx);
 
 };
 

--- a/src/rn2xx3.h
+++ b/src/rn2xx3.h
@@ -41,6 +41,26 @@ class rn2xx3
 {
   public:
 
+    enum received_t {
+      busy,
+      frame_counter_err_rejoin_needed,
+      invalid_data_len,
+      invalid_param,
+      mac_err,
+      mac_paused,
+      mac_rx,
+      mac_tx_ok,
+      no_free_ch,
+      not_joined,
+      ok,
+      radio_err,
+      radio_tx_ok,
+      silent,
+      UNKNOWN
+    };
+
+    static received_t decodeReceived(const String& receivedData);
+
     /*
      * A simplified constructor taking only a Stream ({Software/Hardware}Serial) object.
      * The serial port should already be initialised when initialising this library.
@@ -242,6 +262,8 @@ class rn2xx3
     //Flags to switch code paths. Default is to use OTAA.
     bool _otaa = true;
 
+    bool _needsHardReset = false;
+
     //The default address to use on TTN if no address is defined.
     //This one falls in the "testing" address space.
     String _devAddr = "03FFBEEF";
@@ -268,6 +290,7 @@ class rn2xx3
     RN2xx3_t configureModuleType();
 
     void sendEncoded(String);
+
 };
 
 #endif


### PR DESCRIPTION
I also did split a lot of raw command calls into separate functions to make them better readable and also reduce the number of strings used in the code.

Almost all functions with String type arguments did not use const String reference.
This means every call does perform a deepcopy (and thus lots of memory re-allocations)

The library as it is in this PR is also being used now in ESPeasy.
See https://github.com/letscontrolit/ESPEasy/pull/2539

Later on, I will change it into an async version so the controller does not have to wait for the packet to be sent or wait for a long time for an acknowledgement if asked for.
But such a change will be a breaking change in how to interface with the library.
When that's ready, I will again make a pull request.