### PR TITLE
Quick fix on HDOP calculation.

### DIFF
--- a/examples/TheThingsUno-GPSshield-TTN-Mapper-binary/TheThingsUno-GPSshield-TTN-Mapper-binary.ino
+++ b/examples/TheThingsUno-GPSshield-TTN-Mapper-binary/TheThingsUno-GPSshield-TTN-Mapper-binary.ino
@@ -192,7 +192,7 @@ void build_packet()
   txBuffer[6] = ( altitudeGps >> 8 ) & 0xFF;
   txBuffer[7] = altitudeGps & 0xFF;
 
-  hdopGps = gps.hdop.value()/10;
+  hdopGps = gps.hdop.value()*10;
   txBuffer[8] = hdopGps & 0xFF;
 
   toLog = "";


### PR DESCRIPTION
The HDOP value was divided on the client and the server resulting in the value of 0 being reported much of the time. Now corrected so multiplied on the client and divided on the server.